### PR TITLE
Add install command using install tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ curl -fsSL https://raw.githubusercontent.com/bad33ndj3/gwt/main/gwt.sh -o ~/bin/
 chmod +x ~/bin/gwt
 ```
 
-Adjust the destination as needed and ensure the directory is in your `PATH`.
+You can also install it in one step with `install`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bad33ndj3/gwt/main/gwt.sh | install -m 755 /usr/local/bin/gwt
+```
+
+Adjust the destination path as needed and ensure the directory is in your `PATH`.
 
 ## Shell helper
 


### PR DESCRIPTION
## Summary
- update README install section with a one-step curl+install command
- explain adjusting the destination path

## Testing
- `shellcheck gwt.sh`
- `bash -n gwt.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bbf149204832eb83c00b24ad7173e