### PR TITLE
Fix README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,21 @@ Use `cd $(gwt <branch>)` to change directories quickly.
 
 ## Installation
 
-Download the script somewhere on your `PATH` and make it executable:
+Download the script somewhere on your `PATH` and make it executable. Create the
+directory if it doesn't already exist:
 
 ```bash
+mkdir -p ~/bin
 curl -fsSL https://raw.githubusercontent.com/bad33ndj3/gwt/main/gwt.sh -o ~/bin/gwt
 chmod +x ~/bin/gwt
 ```
 
-You can also install it in one step with `install`:
+You can also place it directly in a system directory:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bad33ndj3/gwt/main/gwt.sh | install -m 755 /usr/local/bin/gwt
+curl -fsSL https://raw.githubusercontent.com/bad33ndj3/gwt/main/gwt.sh \
+  -o /usr/local/bin/gwt
+chmod +x /usr/local/bin/gwt
 ```
 
 Adjust the destination path as needed and ensure the directory is in your `PATH`.


### PR DESCRIPTION
## Summary
- clarify installation steps
- ensure `~/bin` exists and use a cross-platform command

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686bcd99a2e4832e93d150501ad1665d