### PR TITLE
Fix strict mode in gwt.sh

### DIFF
--- a/gwt.sh
+++ b/gwt.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-set -euo pipefail
+# Enable strict mode only when executed directly, not when sourced
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    set -euo pipefail
+fi
 
 # gwt - change to the worktree for the given branch
 # Source this file in your shell configuration to use the function.


### PR DESCRIPTION
## Summary
- avoid setting `set -euo pipefail` when gwt.sh is sourced

## Testing
- `bash -n gwt.sh`


------
https://chatgpt.com/codex/tasks/task_e_686bd43970bc832eb757068edd443dd5