### PR TITLE
Add bash completion for gwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ source ~/.gwt.sh
 ```
 
 Reload your shell and run `gwt <branch>` to jump to that worktree.
+
+### Tab Completion
+
+When sourced, `gwt.sh` now installs a Bash completion function. Press `Tab`
+after typing `gwt` to see available branches that already have worktrees.

--- a/gwt.sh
+++ b/gwt.sh
@@ -42,6 +42,20 @@ gwt() {
     cd "$path" || return
 }
 
+# Autocomplete branch names with existing worktrees
+__gwt_complete() {
+    local cur branches
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        branches=$(git worktree list --porcelain 2>/dev/null | awk '/^branch /{sub("^refs\/heads/","",$2); print $2}')
+        COMPREPLY=( $(compgen -W "$branches" -- "$cur") )
+    else
+        COMPREPLY=()
+    fi
+}
+
+complete -o default -F __gwt_complete gwt
+
 # Allow execution as a script for backward compatibility
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     gwt "$@"


### PR DESCRIPTION
## Summary
- add a Bash completion helper in `gwt.sh`
- document the new tab completion feature in the README

## Testing
- `shellcheck gwt.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bd63d7e68832e8af79a2ccdea3f2c